### PR TITLE
Fix save choiced answer when reload exam page

### DIFF
--- a/exammanagement/main/static/javascript/script.js
+++ b/exammanagement/main/static/javascript/script.js
@@ -35,6 +35,7 @@ jQuery(document).ready(function ($) {
     $("#countdown").text("Countdown expired");
     // Automatically submit the exam form
     $("#exam-form").submit();
+    localStorage.clear();
   }
   updateCountdown = function () {
     if (intTime > 0) {
@@ -43,9 +44,24 @@ jQuery(document).ready(function ($) {
       countdownElement.text(`${minutes}:${seconds < 10 ? "0" : ""}${seconds}`);
       --intTime;
       setTimeout(updateCountdown, 1000);
-    } else {
+    } else if (intTime <= 0 && intTime != null) {
       submitExamAndRedirect();
     }
   };
   updateCountdown();
+
+  $('input[type="radio"]').on("change", function () {
+    var questionId = $(this).attr("name").replace("question_", "");
+    var selectedAnswerId = $(this).val();
+
+    localStorage.setItem("question_" + questionId, selectedAnswerId);
+  });
+
+  $('input[type="radio"]').each(function () {
+    var questionId = $(this).attr("name").replace("question_", "");
+    var selectedAnswerId = localStorage.getItem("question_" + questionId);
+    if (selectedAnswerId === $(this).val()) {
+      $(this).prop("checked", true);
+    }
+  });
 });

--- a/exammanagement/main/views.py
+++ b/exammanagement/main/views.py
@@ -106,8 +106,8 @@ def enroll_subject(request, subject_id):
 def user_profile(request):
     user = request.user
     enrolled_subjects = Enroll.objects.filter(
-        user=user)[:3]
-    tests = Test.objects.filter(user=user)[:3]
+        user=user).order_by("-id")[:3]
+    tests = Test.objects.filter(user=user).order_by("-completed_at")[:3]
 
     context = {
         'user': user,
@@ -212,8 +212,9 @@ def __submit_test(request, test, choices):
             answer_key)
         choice.answer = Answer.objects.filter(id=answer_id).first()
         choice.save()
-        if choice.answer.is_correct:
-            total_score += 1
+        if choice.answer:
+            if choice.answer.is_correct:
+                total_score += 1
     __delete_test_sesstion(request)
     request.session['is-examing'] = False
     test.status = 1


### PR DESCRIPTION
## Related Tickets
- [#68686](https://edu-redmine.sun-asterisk.vn/issues/68686)

## WHAT (optional)
- Sửa lại bug người dùng lỡ load lại trang khi làm bài thì không lưu lại câu trả lời đã chọn

## HOW
- Khi onchange lựa chọn thì lưu lại trong local storage

## Evidence (Screenshot or Video)

https://github.com/awesome-academy/hn_python_naitei19-exam_management_system/assets/85157587/755e29a8-19a5-4b25-8610-8b633d50f370


